### PR TITLE
Make syntax highlighting work in Markdown code blocks

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 
 # vscode-bnf
-[![Version](https://vsmarketplacebadge.apphb.com/version/Vallentin.vscode-bnf.svg)](https://marketplace.visualstudio.com/items?itemName=Vallentin.vscode-bnf)
-[![Installs](https://vsmarketplacebadge.apphb.com/installs/Vallentin.vscode-bnf.svg)](https://marketplace.visualstudio.com/items?itemName=Vallentin.vscode-bnf)
+[![Version](https://img.shields.io/visual-studio-marketplace/v/Vallentin.vscode-bnf)](https://marketplace.visualstudio.com/items?itemName=Vallentin.vscode-bnf)
+[![Installs](https://img.shields.io/visual-studio-marketplace/i/Vallentin.vscode-bnf)](https://marketplace.visualstudio.com/items?itemName=Vallentin.vscode-bnf)
 
 This extension adds BNF and EBNF syntax highlighting to Visual Studio Code.
 

--- a/package.json
+++ b/package.json
@@ -45,6 +45,16 @@
 				"language": "bnf",
 				"scopeName": "source.bnf",
 				"path": "./syntaxes/bnf.tmLanguage.json"
+			},
+			{
+				"scopeName": "source.markdown.codeblock.bnf",
+				"path": "./syntaxes/bnf.markdown.tmGrammar.json",
+				"injectTo": [
+					"text.html.markdown"
+				],
+				"embeddedLanguages": {
+					"meta.embedded.block.bnf": "bnf"
+				}
 			}
 		]
 	}

--- a/syntaxes/bnf.markdown.tmGrammar.json
+++ b/syntaxes/bnf.markdown.tmGrammar.json
@@ -1,0 +1,45 @@
+{
+    "fileTypes": [],
+    "injectionSelector": "L:text.html.markdown",
+    "patterns": [
+        {
+            "include": "#bnf-code-block"
+        }
+    ],
+    "repository": {
+        "bnf-code-block": {
+            "begin": "(^|\\G)(\\s*)(\\`{3,}|~{3,})\\s*(?i:(bnf)(\\s+[^`~]*)?$)",
+            "name": "markup.fenced_code.block.markdown",
+            "end": "(^|\\G)(\\2|\\s{0,3})(\\3)\\s*$",
+            "beginCaptures": {
+                "3": {
+                    "name": "punctuation.definition.markdown"
+                },
+                "4": {
+                    "name": "fenced_code.block.language.markdown"
+                },
+                "5": {
+                    "name": "fenced_code.block.language.attributes.markdown"
+                }
+            },
+            "endCaptures": {
+                "3": {
+                    "name": "punctuation.definition.markdown"
+                }
+            },
+            "patterns": [
+                {
+                    "begin": "(^|\\G)(\\s*)(.*)",
+                    "while": "(^|\\G)(?!\\s*([`~]{3,})\\s*$)",
+                    "contentName": "meta.embedded.block.bnf",
+                    "patterns": [
+                        {
+                            "include": "source.bnf"
+                        }
+                    ]
+                }
+            ]
+        }
+    },
+    "scopeName": "source.markdown.codeblock.bnf"
+}


### PR DESCRIPTION
- change the icons in the README to PNG, as SVG icons are not allowed by the Marketplace
- make BNF syntax highlighting work in Markdown code blocks too. Using language identifier `bnf` 

Example of supported Markdown code fence:
```text
 ```bnf
  <non_terminal> ::= ...
```